### PR TITLE
Changed try button to be shown by default

### DIFF
--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -58,7 +58,7 @@
                     Test this endpoint
                 </h4>
 
-                <div class="sandbox_header collapse" data-content id="test-{{parentId}}_{{nickname}}">
+                <div class="sandbox_header collapse in" data-content id="test-{{parentId}}_{{nickname}}">
                     <input class="submit btn btn-primary" name="commit" type="submit" value="Try"
                            data-target="#get_clients-modal-request">
                     <a href="#" class="response_hider hide" style="display: inline;">Hide Response</a>


### PR DESCRIPTION
Do you like this? I noticed Auth0 has it shown by default. It's not exactly super intuitive to know to click the text I felt like.

Random question since issues aren't enabled on this repo, do you have any ideas about OAuth?
