### PR TITLE
Small change to operation title and scope button styling

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -122,7 +122,6 @@
         font-size: 32px;
         font-weight: 200;
         line-height: 1;
-        padding-right: 160px
     }
 }
 

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1032,6 +1032,7 @@
 }
 
 .api-popup-scopes .scopes .scope {
+    cursor: pointer;
     display: inline-block;
     border: 1px solid #e8eaeb;
     border-radius: 20px;


### PR DESCRIPTION
The padding-right on Auth0 I think is there since they have the "collapse samples" text and removing it lets the text flow for the entire width.

I saw they had the cursor set to pointer as well making it look more like a button. Do you like these?
