### PR TITLE
Removed overriding font family for code tag in api explorer css

### DIFF
--- a/dist/css/api-explorer.css
+++ b/dist/css/api-explorer.css
@@ -214,7 +214,6 @@
     padding: 2px 4px;
     border-radius: 4px;
     font-size: 10px;
-    font-family: menlo;
     border: 1px solid rgba(0, 0, 0, .07)
 }
 

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -214,7 +214,6 @@
     padding: 2px 4px;
     border-radius: 4px;
     font-size: 10px;
-    font-family: menlo;
     border: 1px solid rgba(0, 0, 0, .07)
 }
 


### PR DESCRIPTION
I was viewing this in a Windows VM earlier and noticed the font was a bit off for `<code>` tags and so I inspected and it's overriding the font family with menlo, but it already has a font family of `Menlo, Monaco, Consolas, "Courier New", monospace` it would inherit without the override from another stylesheet.
