### PR TITLE
Removed disabling resizing of form control textarea elements

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -322,7 +322,6 @@
 }
 
 .swagger-section .parameter-item .form-control {
-    resize: none;
     width: auto;
     max-width: 100%
 }


### PR DESCRIPTION
Would you like this? If the body schema is large it is difficult to type in and a lot of browsers support resizing which is nice to be able to enlarge the textarea.

![screen shot 2015-06-11 at 1 44 28 pm](https://cloud.githubusercontent.com/assets/207171/8115298/0e58d276-1040-11e5-99b8-d218bcef0703.png)
