### PR TITLE
Added ignoring file body parameters from creating body schema section in operation view

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -235,6 +235,8 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
   },
 
   addBodyModel: function (param) {
+    if (param.type === 'file') return;
+
     var bodySample = {
       sampleJSON: param.sampleJSON,
       isParam: true,


### PR DESCRIPTION
If you have a file upload it puts an empty body schema section in the operation view.
