### PR TITLE
Change default spec url for easy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The theme will adapt to screen size and works on tablets and mobile phones.
 
 [![Swagger Theme example](dist/images/Swagger_explorer_min.png)](http://ecs.bobbytech.dk/api)
 
-Give it a [try](http://swaggerui.herokuapp.com/) and enter your own swagger definition.
+Give it a [try](http://swaggerui.herokuapp.com/?url=http://petstore.swagger.io/v2/swagger.json) and enter your own swagger definition.
 
 
 ## Disclaimer

--- a/dist/index.html
+++ b/dist/index.html
@@ -44,7 +44,7 @@
             if (url && url.length > 1) {
                 url = decodeURIComponent(url[1]);
             } else {
-                url = "http://petstore.swagger.io/v2/swagger.json";
+                url = window.location + "/swagger.json";
             }
 
             window.swaggerUi = new SwaggerUi({

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -44,7 +44,7 @@
             if (url && url.length > 1) {
                 url = decodeURIComponent(url[1]);
             } else {
-                url = "http://petstore.swagger.io/v2/swagger.json";
+                url = window.location + "/swagger.json";
             }
 
             window.swaggerUi = new SwaggerUi({


### PR DESCRIPTION
The default url should make it as easy as possible to integrate with existing systems.
