### PR TITLE
Select the correct scope after the auth selection

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -138,7 +138,7 @@ function handleLogin() {
       }
     }
     var scopes = [];
-    var o = $('.scopes').find('.active');
+    var o = $(".scopes:last .active");
     for (k = 0; k < o.length; k++) {
       var scope = $(o[k]).attr('data-toggle-scope');
       if (scopes.indexOf(scope) === -1)


### PR DESCRIPTION
Currently previously selected scopes are still selected because the modal dialogs are not removed but just hidden. This selects the latest modal dialog
