### PR TITLE
always trigger click event for first resource in navigation bar when MainView is rendered

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -142,10 +142,10 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       $('.optionsWrapper', $(this)).hide();
     });
 
-    if (window.location.hash.length === 0 ) {
-      var n = $(this.el).find("#resources_nav [data-resource]").first();
+    var n = $(this.el).find("#resources_nav [data-resource]").first();
+    if (n.length) {
       n.trigger("click");
-      $(window).scrollTop(0)
+      $(window).scrollTop(0);
     }
 
     return this;


### PR DESCRIPTION
Description:
previously hash length in url was used to activate the first resource.
when explore button clicked, in the navigation bar first resource is not
activated due to above reason.
Hence changed flow to activate first resource in navigation bar
irrespective of window.location.hash.